### PR TITLE
Add combos to DC60

### DIFF
--- a/keyboards/alf/dc60/keymaps/endlessreform/combos.def
+++ b/keyboards/alf/dc60/keymaps/endlessreform/combos.def
@@ -1,0 +1,1 @@
+SUBS(sdWinTab, SS_LGUI(SS_TAP(X_TAB)), KC_S, KC_D)

--- a/keyboards/alf/dc60/keymaps/endlessreform/config.h
+++ b/keyboards/alf/dc60/keymaps/endlessreform/config.h
@@ -17,4 +17,4 @@
 #pragma once
 
 // place overrides here
-#define RGBLIGHT_LAYERS
+#define COMBO_TERM 20

--- a/keyboards/alf/dc60/keymaps/endlessreform/keymap.c
+++ b/keyboards/alf/dc60/keymaps/endlessreform/keymap.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include QMK_KEYBOARD_H
+/* See QMK combo docs "Dictionary Management" */
+#include "g/keymap_combo.h"
 #define BASE 0
 #define NAV 1
 #define PUNC 2
@@ -114,9 +116,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     [NAV] = LAYOUT_all(
         KC_ESC, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, _______, _______,
-        _______, KC_VOLD, LCTL(KC_RIGHT), KC_VOLU, _______, _______, KC_END, KC_PGDN, KC_PGUP, KC_HOME, _______, _______, _______, KC_DEL,
+        _______, KC_VOLD, _______, KC_VOLU, _______, _______, KC_END, KC_PGDN, KC_PGUP, KC_HOME, _______, _______, _______, KC_DEL,
         _______, KC_MPRV, KC_MPLY, KC_MNXT, _______, _______, KC_LEFT, KC_DOWN, KC_UP, KC_RIGHT, _______, _______, _______,
-        _______, KC_LSFT, _______, _______, _______, _______, LCTL(KC_LEFT), LCTL(LSFT(KC_LEFT)), _______, _______, LCTL(LSFT(KC_RIGHT)), _______, _______,
+        _______, KC_LSFT, _______, _______, CMB_TOG, _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RESET
     ),
 
@@ -148,8 +150,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         GIT_KEY, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, DDASH, _______, _______, RM,
         TAG, _______, _______, _______, REMOTE, _______, _______, UPSTREAM, INIT, ORIGIN, _______, _______, _______, REVERT,
         PUSH, _______, STATUS, DEVELOP, _______, GLOBAL, _______, _______, _______, LOG, _______, _______, COMMIT,
-        REBASE, _______, _______, _______, _______, _______, _______, _______, MAIN, _______, _______, _______, CHECKOUT,
-        CHECKOUT, ADD, BRANCH, PULL, MERGE, SPC, SPC, SPC, STASH, STASH, FETCH, FETCH, CLONE
+        REBASE, _______, _______, _______, _______, _______, _______, _______, MAIN, _______, _______, _______, CHECKOUT, CHECKOUT, ADD,
+        BRANCH, PULL, MERGE, SPC, SPC, SPC, STASH, STASH, FETCH, FETCH, CLONE
     ),
 };
 

--- a/keyboards/alf/dc60/keymaps/endlessreform/rules.mk
+++ b/keyboards/alf/dc60/keymaps/endlessreform/rules.mk
@@ -24,3 +24,5 @@ BLUETOOTH_ENABLE = no       # Enable Bluetooth with the Adafruit EZ-Key HID
 AUDIO_ENABLE = no           # Audio output on port C6
 FAUXCLICKY_ENABLE = no      # Use buzzer to emulate clicky switches
 TAP_DANCE_ENABLE = yes
+COMBO_ENABLE = yes
+VPATH += keyboards/gboards/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

- Add combo support to DC60 using gboard's macro
- Add first combo: `s+d -> OS+Tab`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [X ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

